### PR TITLE
add MZ_DEPS_USE_GLOBAL to solve Issue #20

### DIFF
--- a/include/backend.h
+++ b/include/backend.h
@@ -16,6 +16,10 @@
 #define MUZZLE_FALSE 0
 #define MUZZLE_TRUE 1
 
-#include "../deps/glfw/include/GLFW/glfw3.h"
+#ifdef MZ_DEPS_USE_GLOBAL
+    #include <GLFW/glfw3.h>
+#else
+    #include "../deps/glfw/include/GLFW/glfw3.h"
+#endif
 
 typedef GLFWwindow* MUZZLE_WINDOW;


### PR DESCRIPTION
This PR was created to solve #20.

The solution now allows you to define `MZ_DEPS_USE_GLOBAL` that includes <GLFW/glfw3.h> instead of including it from the deps folder. This may cause some issues with glfw3.h in the deps folder may be a different version to what a developer might have installed globally. Anyways this is up to the developer on what header file to choose from.

```c
#define MZ_DEPS_USE_GLOBAL
#define MUZZLE_DEPS
#include <Muzzle.h>
#include <stdio.h>
#define SCREEN_WIDTH 1280
#define SCREEN_HEIGHT 720

Applet applet;

void OnAppletUpdate()
{

    while (keep_applet(applet.window_handle))
    {
        begin_drawing();
            clear_screen(GRAY);
        end_drawing(&applet);
    }
    
}

int main(void)
{
    applet = InitializeApplet(SCREEN_WIDTH, SCREEN_HEIGHT, "Muzzle [CORE] - Blank Window", MUZZLE_FALSE, MUZZLE_FALSE);
    StartApplet(&applet);

    QuitMuzzle(applet);
    return 0;
}
```