### PR TITLE
Shaders + Matrix: Added mat3 and mat4

### DIFF
--- a/include/core/matrix.h
+++ b/include/core/matrix.h
@@ -1,0 +1,4 @@
+#pragma once
+
+typedef float* mat3;
+typedef float* mat4;

--- a/include/core/matrix.h
+++ b/include/core/matrix.h
@@ -1,4 +1,4 @@
 #pragma once
 
-typedef float* mat3;
-typedef float* mat4;
+typedef float mat3[9];
+typedef float mat4[16];

--- a/include/modern_pipeline/Shaders.h
+++ b/include/modern_pipeline/Shaders.h
@@ -3,6 +3,7 @@
 #include "../core/tint.h"
 #include "../core/Error.h"
 #include "../core/vector.h"
+#include "../core/matrix.h"
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -29,9 +30,8 @@ MZ_API void upload_shader_float(shader_program program, const char* var, float v
 MZ_API void upload_shader_vec2(shader_program program, const char* var, vec2 value);
 MZ_API void upload_shader_vec3(shader_program program, const char* var, vec3 value);
 MZ_API void upload_shader_vec4(shader_program program, const char* var, vec4 value);
-
-// TODO: Add upload_shader matrix3, matrix4
-// Reference code for implementing matrix types: https://github.com/raysan5/raylib/blob/master/src/raylib.h#L217
+MZ_API void upload_shader_mat3(shader_program program, const char* var, mat3 value);
+MZ_API void upload_shader_mat4(shader_program program, const char* var, mat4 value);
 
 MZ_API void attach_shader_program(shader_program shader);
 MZ_API void unload_shader_program(shader_program shader);

--- a/src/Shaders.c
+++ b/src/Shaders.c
@@ -89,7 +89,7 @@ shader_program link_shader(shader vertex, shader fragment)
 
 void upload_shader_int(shader_program program, const char* var, int value)
 {
-    int uniform_location = glGetUniformLocation(program, var);
+    GLuint uniform_location = glGetUniformLocation(program, var);
     glUseProgram(program);
     glUniform1i(uniform_location, value);
     
@@ -100,7 +100,7 @@ void upload_shader_int(shader_program program, const char* var, int value)
 
 void upload_shader_float(shader_program program, const char* var, float value)
 {
-    int uniform_location = glGetUniformLocation(program, var);
+    GLuint uniform_location = glGetUniformLocation(program, var);
     glUseProgram(program);
     glUniform1f(uniform_location, value);
     
@@ -111,7 +111,7 @@ void upload_shader_float(shader_program program, const char* var, float value)
 
 void upload_shader_vec2(shader_program program, const char* var, vec2 value)
 {
-    int uniform_location = glGetUniformLocation(program, var);
+    GLuint uniform_location = glGetUniformLocation(program, var);
     glUseProgram(program);
     glUniform2f(uniform_location, value.x, value.y);
     
@@ -122,7 +122,7 @@ void upload_shader_vec2(shader_program program, const char* var, vec2 value)
 
 void upload_shader_vec3(shader_program program, const char* var, vec3 value)
 {
-    int uniform_location = glGetUniformLocation(program, var);
+    GLuint uniform_location = glGetUniformLocation(program, var);
     glUseProgram(program);
     glUniform3f(uniform_location, value.x, value.y, value.z);
     
@@ -133,12 +133,34 @@ void upload_shader_vec3(shader_program program, const char* var, vec3 value)
 
 void upload_shader_vec4(shader_program program, const char* var, vec4 value)
 {
-    int uniform_location = glGetUniformLocation(program, var);
+    GLuint uniform_location = glGetUniformLocation(program, var);
     glUseProgram(program);
     glUniform4f(uniform_location, value.x, value.y, value.z, value.w);
     
     #ifdef MUZZLE_VERBOSE
         log_status(STATUS_INFO, "Uploaded vec4 to shader");
+    #endif
+}
+
+void upload_shader_mat3(shader_program program, const char* var, mat3 value)
+{
+    GLuint uniform_location = glGetUniformLocation(program, var);
+    glUseProgram(program);
+    glUniformMatrix3fv(uniform_location, 1, 0, value);
+    
+    #ifdef MUZZLE_VERBOSE
+        log_status(STATUS_INFO, "Uploaded mat3 to shader");
+    #endif
+}
+
+void upload_shader_mat4(shader_program program, const char* var, mat  value)
+{
+    GLuint uniform_location = glGetUniformLocation(program, var);
+    glUseProgram(program);
+    glUniformMatrix3fv(uniform_location, 1, 0, value);
+    
+    #ifdef MUZZLE_VERBOSE
+        log_status(STATUS_INFO, "Uploaded mat4 to shader");
     #endif
 }
 

--- a/src/Shaders.c
+++ b/src/Shaders.c
@@ -144,6 +144,14 @@ void upload_shader_vec4(shader_program program, const char* var, vec4 value)
 
 void upload_shader_mat3(shader_program program, const char* var, mat3 value)
 {
+    if (!value)
+    {
+        #ifdef MUZZLE_VERBOSE
+            log_status(STATUS_ERROR, "Failed to upload mat3 to shader");
+        #endif
+        return;
+    }
+
     GLuint uniform_location = glGetUniformLocation(program, var);
     glUseProgram(program);
     glUniformMatrix3fv(uniform_location, 1, 0, value);
@@ -153,8 +161,16 @@ void upload_shader_mat3(shader_program program, const char* var, mat3 value)
     #endif
 }
 
-void upload_shader_mat4(shader_program program, const char* var, mat  value)
+void upload_shader_mat4(shader_program program, const char* var, mat4 value)
 {
+    if (!value)
+    {
+        #ifdef MUZZLE_VERBOSE
+            log_status(STATUS_ERROR, "Failed to upload mat4 to shader");
+        #endif
+        return;
+    }
+
     GLuint uniform_location = glGetUniformLocation(program, var);
     glUseProgram(program);
     glUniformMatrix3fv(uniform_location, 1, 0, value);

--- a/src/Shaders.c
+++ b/src/Shaders.c
@@ -144,17 +144,11 @@ void upload_shader_vec4(shader_program program, const char* var, vec4 value)
 
 void upload_shader_mat3(shader_program program, const char* var, mat3 value)
 {
-    if (!value)
-    {
-        #ifdef MUZZLE_VERBOSE
-            log_status(STATUS_ERROR, "Failed to upload mat3 to shader");
-        #endif
-        return;
-    }
+    // TODO: Assert if value is NULL with MZ_ASSERT();
 
     GLuint uniform_location = glGetUniformLocation(program, var);
     glUseProgram(program);
-    glUniformMatrix3fv(uniform_location, 1, 0, value);
+    glUniformMatrix3fv(uniform_location, 1, MUZZLE_FALSE, value);
     
     #ifdef MUZZLE_VERBOSE
         log_status(STATUS_INFO, "Uploaded mat3 to shader");
@@ -163,17 +157,11 @@ void upload_shader_mat3(shader_program program, const char* var, mat3 value)
 
 void upload_shader_mat4(shader_program program, const char* var, mat4 value)
 {
-    if (!value)
-    {
-        #ifdef MUZZLE_VERBOSE
-            log_status(STATUS_ERROR, "Failed to upload mat4 to shader");
-        #endif
-        return;
-    }
+    // TODO: Assert if value is NULL with MZ_ASSERT();
 
     GLuint uniform_location = glGetUniformLocation(program, var);
     glUseProgram(program);
-    glUniformMatrix3fv(uniform_location, 1, 0, value);
+    glUniformMatrix3fv(uniform_location, 1, MUZZLE_FALSE, value);
     
     #ifdef MUZZLE_VERBOSE
         log_status(STATUS_INFO, "Uploaded mat4 to shader");


### PR DESCRIPTION
This PR implements the matrix support outlined in issue #34. All commits are non-breaking and can be found in `include\modern_pipeline\shaders.h`, `Shaders.c` and `include\core\matrix.h`